### PR TITLE
Removes padding-left that caused bad scrolling behavior.

### DIFF
--- a/index.less
+++ b/index.less
@@ -40,10 +40,6 @@ atom-text-editor, :host {
     color: @light-gray;
   }
 
-  .scroll-view {
-    padding-left: 10px;
-  }
-
   .invisible {
     color: @syntax-text-color;
   }


### PR DESCRIPTION
Fixes atom/atom#8343# 

The padding on the left of the scroll-view was not found to exist in other 'default' themes. It broke scrolling, as detailed in atom/atom#8343. Removing the padding fixes it and is consistent with every other default syntax theme currently shipping with atom.