### PR TITLE
Remove underlines

### DIFF
--- a/index.less
+++ b/index.less
@@ -61,7 +61,6 @@ atom-text-editor, :host {
 
   &.name.type {
     color: @light-orange;
-    text-decoration: underline;
   }
 
   &.other.inherited-class {
@@ -209,7 +208,6 @@ atom-text-editor, :host {
 
   &.name.tag {
     color: @red;
-    text-decoration: underline;
   }
 
   &.other.attribute-name {


### PR DESCRIPTION
#### Before:
![screen shot 2015-09-05 at 12 51 25 pm](https://cloud.githubusercontent.com/assets/378023/9697589/e03c3664-53cc-11e5-9392-870c1af72798.png)

#### After:
![screen shot 2015-09-05 at 12 51 02 pm](https://cloud.githubusercontent.com/assets/378023/9697590/e9231608-53cc-11e5-831d-1f1540170025.png)

#### Reasoning:
- The original theme doesn't underlines
- Arguably harder to read.. like the `y` in `body`.
- There doesn't seem to be a specific reason to have underlines, maybe as a way to differentiate more

#### "I prefer the old way":

To keep the underlines like they used to be, you can add this to your `styles.less` file:

```less
// add underline to tag + type 
atom-text-editor::shadow {
  .entity.name.tag,
  .entity.name.type {
    text-decoration: underline;
  }
}
```

Closes #19