### PR TITLE
Colorize bracket-matcher

### DIFF
--- a/index.less
+++ b/index.less
@@ -51,6 +51,10 @@ atom-text-editor, :host {
   .selection .region {
     background-color: @syntax-selection-color;
   }
+
+  .bracket-matcher .region {
+    border-color: @syntax-result-marker-color;
+  }
 }
 
 .comment {


### PR DESCRIPTION
Makes the `bracket-matcher` less vivid.

Before:

![screen shot 2015-09-07 at 10 36 14 am](https://cloud.githubusercontent.com/assets/378023/9708041/204e0b80-5551-11e5-94cb-946ee5f0748e.png)

After:

![screen shot 2015-09-07 at 10 43 34 am](https://cloud.githubusercontent.com/assets/378023/9708044/294d8274-5551-11e5-8b70-0dea49b47c4b.png)


Fixes #15