### PR TITLE
Restyle gutter

### DIFF
--- a/index.less
+++ b/index.less
@@ -18,11 +18,11 @@ atom-text-editor, :host {
 
   .gutter {
     background-color: @syntax-gutter-background-color;
-    border-right: 2px solid @syntax-gutter-background-color-selected;
     color: @syntax-gutter-text-color;
 
     .line-number {
       padding: 0 0.25em 0 0.5em;
+      -webkit-font-smoothing: antialiased;
       &.cursor-line {
         background-color: @syntax-gutter-background-color-selected;
         color: @syntax-gutter-text-color-selected;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -6,7 +6,7 @@
 // General colors
 @syntax-text-color: @very-light-gray;
 @syntax-cursor-color: white;
-@syntax-selection-color: lighten(@dark-gray, 10%);
+@syntax-selection-color: @gray;
 @syntax-selection-flash-color: @very-light-gray;
 @syntax-background-color: @very-dark-gray;
 
@@ -20,10 +20,10 @@
 @syntax-result-marker-color-selected: white;
 
 // Gutter colors
-@syntax-gutter-text-color: @very-light-gray;
-@syntax-gutter-text-color-selected: @syntax-gutter-text-color;
-@syntax-gutter-background-color: @dark-gray;
-@syntax-gutter-background-color-selected: @gray;
+@syntax-gutter-text-color: @light-gray;
+@syntax-gutter-text-color-selected: @very-light-gray;
+@syntax-gutter-background-color: @syntax-background-color;
+@syntax-gutter-background-color-selected: @syntax-selection-color;
 
 // For git diff info. i.e. in the gutter
 @syntax-color-renamed: @blue;


### PR DESCRIPTION
This PR restyles the gutter. It feels a bit odd when the code touches the gutter border. There could be an extra margin, or no gutter border/background, like in the PR. It also makes the gutter stand out less and the focus can shift to the actual code.

Before:

![screen shot 2015-09-25 at 8 45 21 pm](https://cloud.githubusercontent.com/assets/378023/10099628/5e3ff8b2-63c6-11e5-996f-b4c2e37efbb4.png)

After:

![screen shot 2015-09-25 at 8 44 22 pm](https://cloud.githubusercontent.com/assets/378023/10099620/4290486a-63c6-11e5-872c-e7f8f05ef3bf.png)

- [x] remove background
- [x] remove border
- [x] thinner text
- [x] color tweaks