### PR TITLE
Add JSON styles

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,5 +1,9 @@
 
 // Base16 Tomorrow dark
 
-@import 'styles/editor';
-@import 'styles/language';
+@import (reference) "styles/syntax-variables";
+
+@import 'editor';
+@import 'language';
+
+@import 'languages/json';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "theme": "syntax",
   "version": "1.0.0",
   "description": "Base16 dark theme for Atom",
+  "keywords": [
+    "base16",
+    "dark",
+    "syntax"
+  ],
   "repository": "https://github.com/atom/base16-tomorrow-dark-theme",
   "license": "MIT",
   "engines": {

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,6 +1,8 @@
-@import "syntax-variables";
 
-atom-text-editor, :host {
+// Editor styles (background, gutter, guides)
+
+atom-text-editor, // <- remove when Shadow DOM can't be disabled
+:host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,4 +1,5 @@
-@import "syntax-variables";
+
+// Language syntax highlighting
 
 .comment {
   color: @gray;

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,0 +1,21 @@
+.source.json {
+  .meta.structure.dictionary.json {
+    & > .string.quoted.json {
+      & > .punctuation.string {
+        color: @red;
+      }
+      color: @red;
+    }
+  }
+
+  .meta.structure.dictionary.json, .meta.structure.array.json {
+    & > .value.json > .string.quoted.json,
+    & > .value.json > .string.quoted.json > .punctuation {
+      color: @green;
+    }
+
+    & > .constant.language.json {
+      color: @cyan;
+    }
+  }
+}


### PR DESCRIPTION
Added JSON syntax coloring:

![json-syntax](https://cloud.githubusercontent.com/assets/1847621/11752789/7faf8c2e-a052-11e5-8191-311da152eab7.PNG)

Updated the way files are imported (similar to [One Dark](https://github.com/atom/one-dark-syntax), another default syntax theme).

Added keywords to `package.json`.