### PR TITLE
Adjust invisible color

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -10,9 +10,9 @@
 @syntax-background-color:      @black;
 
 // Guide colors
-@syntax-wrap-guide-color:          @very-dark-gray;
-@syntax-indent-guide-color:        @dark-gray;
-@syntax-invisible-character-color: @dark-gray;
+@syntax-wrap-guide-color:          mix(@gray, @dark-gray);
+@syntax-indent-guide-color:        mix(@gray, @dark-gray);
+@syntax-invisible-character-color: mix(@gray, @dark-gray);
 
 // For find and replace markers
 @syntax-result-marker-color:          @gray;


### PR DESCRIPTION
So that invisibles can still be seen when making a selection.

Fixes #28

:weary: Before | :smiley: After
--- | ---
![screen shot 2016-08-25 at 12 52 29 pm](https://cloud.githubusercontent.com/assets/378023/17956194/d416841c-6ac2-11e6-8d07-d663f5d30b08.png) | ![screen shot 2016-08-25 at 12 44 13 pm](https://cloud.githubusercontent.com/assets/378023/17956197/d98f62ec-6ac2-11e6-8d1b-183d02b07378.png)

Note: It would **still** be different from the [official guide](https://github.com/chriskempson/base16/blob/master/styling.md).