### PR TITLE
Improve coloring inside the classes and methods.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,9 +1,10 @@
 
-// Base16 Tomorrow dark
+// Base16 Tomorrow Dark
 
 @import (reference) "styles/syntax-variables";
 
 @import 'editor';
 @import 'language';
 
+@import 'languages/cs';
 @import 'languages/json';

--- a/styles/language.less
+++ b/styles/language.less
@@ -117,8 +117,16 @@
     }
   }
 
-  &.section.embedded {
-    color: @brown;
+  &.section {
+    &.embedded {
+      color: @brown;
+    }
+
+    &.method,
+    &.class,
+    &.inner-class {
+      color: @syntax-text-color;
+    }
   }
 }
 
@@ -166,10 +174,19 @@
 .meta {
   &.class {
     color: @yellow;
+
+    &.body {
+      color: @syntax-text-color;
+    }
   }
 
   &.link {
     color: @orange;
+  }
+
+  &.method-call,
+  &.method {
+    color: @syntax-text-color;
   }
 
   &.require {

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,5 @@
+.source.cs {
+  .keyword.operator {
+    color: @purple;
+  }
+}


### PR DESCRIPTION
* Fixed the coloring inside the methods, classes, and inner classes. This includes "words", curly brackets, dots (as property accessors).

* Added coloring for the keyword operator in C#. Previously, most of the text in C# was yellow and the keyword operators were white. After the fix, most of the text became white as well, so it was problematic to find the keyword operators. I thought it would be a good idea to colorize them. Note, that this change applies for C# only.

Should also fix the problem, described in issue #27.

---

**C#**

**Before:**

![cs-before](https://cloud.githubusercontent.com/assets/1847621/18225248/31831c56-71f7-11e6-8352-b247ae5ff51c.png)

**After:**

![cs-after](https://cloud.githubusercontent.com/assets/1847621/18225262/6d6a941a-71f7-11e6-9ebb-b056dfa6439d.png)

---

**Java**

**Before:**

![java-before](https://cloud.githubusercontent.com/assets/1847621/18225272/ae64d534-71f7-11e6-881f-67809ee4e26c.png)

**After:**

![java-after](https://cloud.githubusercontent.com/assets/1847621/18225275/b447b692-71f7-11e6-813f-c2df1ad08e20.png)

---

**JavaScript**
> Babel ES6 syntax with [language-babel](https://atom.io/packages/language-babel) plugin.
> Default JavaScript syntax looks good.

**Before:**

![js-babel-before](https://cloud.githubusercontent.com/assets/1847621/18225279/cb38334a-71f7-11e6-8cbe-1767c1cbb884.png)

**After:**

![js-babel-after](https://cloud.githubusercontent.com/assets/1847621/18225280/d08e29d0-71f7-11e6-8e13-3f97777679a2.png)

