### PR TITLE
Fix issue [Inproper url highlight](https://github.com/atom/base16-tom…

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,7 @@
 
 ### Description of the Change
 
-<!--
-
-We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-
--->
+The link in comment need be override with gray color. The link color was blue before fixed.
 
 ### Alternate Designs
 
@@ -25,4 +21,4 @@ We must be able to understand the design of your change from this description. I
 
 ### Applicable Issues
 
-<!-- Enter any applicable Issues here -->
+[Inproper url highlight](https://github.com/atom/base16-tomorrow-dark-theme/issues/38)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,11 @@
 
 ### Description of the Change
 
-The link in comment need be override with gray color. The link color was blue before fixed.
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
 
 ### Alternate Designs
 
@@ -21,4 +25,4 @@ The link in comment need be override with gray color. The link color was blue be
 
 ### Applicable Issues
 
-[Inproper url highlight](https://github.com/atom/base16-tomorrow-dark-theme/issues/38)
+<!-- Enter any applicable Issues here -->

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -3,6 +3,10 @@
 
 .syntax--comment {
   color: @gray;
+
+  .syntax--markup.syntax--link {
+    color: @gray;
+  }
 }
 
 .syntax--entity {


### PR DESCRIPTION


### Description of the Change

The link in comment need be override with gray color. The link color was blue before fixed.


### Applicable Issues

[Inproper url highlight](https://github.com/atom/base16-tomorrow-dark-theme/issues/38)