### PR TITLE
Lower contrast for guide colors

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -10,9 +10,9 @@
 @syntax-background-color:      @black;
 
 // Guide colors
-@syntax-wrap-guide-color:          mix(@gray, @dark-gray);
-@syntax-indent-guide-color:        mix(@gray, @dark-gray);
-@syntax-invisible-character-color: mix(@gray, @dark-gray);
+@syntax-wrap-guide-color:          mix(@gray, @dark-gray, 25%);
+@syntax-indent-guide-color:        mix(@gray, @dark-gray, 25%);
+@syntax-invisible-character-color: mix(@gray, @dark-gray, 25%);
 
 // For find and replace markers
 @syntax-result-marker-color:          @gray;


### PR DESCRIPTION
### Description of the Change

This decreases the contrast for guide (indent guide, invisibles, wrap guide) colors.

Before | After
--- | ---
![screen shot 2018-08-24 at 12 18 18 pm](https://user-images.githubusercontent.com/378023/44563173-f8bf7f80-a797-11e8-91ba-250232274c06.png) | ![screen shot 2018-08-24 at 12 17 43 pm](https://user-images.githubusercontent.com/378023/44563172-f8bf7f80-a797-11e8-966d-a4af14137768.png)


### Alternate Designs

Different contrast.

### Benefits

Guides look more subtle and less distracting.

### Possible Drawbacks

For some people they might be too subtle.

### Applicable Issues

Closes https://github.com/atom/base16-tomorrow-dark-theme/issues/42
