### PR TITLE
Change symbols to cyan

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -60,7 +60,7 @@
   }
 
   &.syntax--other.syntax--symbol {
-    color: @green;
+    color: @cyan;
   }
 }
 


### PR DESCRIPTION
### Description of the Change

This changes symbols from green to cyan.

Before

![screen shot 2018-08-24 at 1 56 58 pm](https://user-images.githubusercontent.com/378023/44566033-3c20ea80-a7a6-11e8-8a2e-3efb99b28776.png) 

After

![screen shot 2018-08-24 at 1 58 16 pm](https://user-images.githubusercontent.com/378023/44566034-3cb98100-a7a6-11e8-8026-9ad483bd43bc.png)


### Alternate Designs

Other color

### Benefits

Easier to distinguish from strings (which are also green).

### Possible Drawbacks

People are already used to green.

### Applicable Issues

Closes https://github.com/atom/base16-tomorrow-dark-theme/issues/44
